### PR TITLE
Now working with custom validation messages

### DIFF
--- a/formbase_model.php
+++ b/formbase_model.php
@@ -18,6 +18,14 @@ class FormBase_Model
 	 * @var array
 	 */
 	public static $rules = array();
+	
+	/**
+	 * The messages array stores Validator messages in an array indexed by
+	 * the field_name to which the messages should be applied in case of errors.
+	 *
+	 * @var array
+	 */
+	public static $messages = array();
 
 	/**
 	 * The validation object is stored here once is_valid() is run.
@@ -86,7 +94,7 @@ class FormBase_Model
 
 		// generate the validator and return its success status
 
-		static::$validation = Validator::make( $input, $field_rules );
+		static::$validation = Validator::make( $input, $field_rules, static::$messages );
 
 		return static::$validation->passes();
 


### PR DESCRIPTION
When using custom validation rules, custom error messages are now
displayed. Just place your custom validation messages inside the
$messages array.
