### PR TITLE
FormBase_Model::all() needs to ensure session data is unserialized first...

### DIFF
--- a/formbase_model.php
+++ b/formbase_model.php
@@ -318,6 +318,9 @@ class FormBase_Model
 	public static function all()
 	{
 
+		if( empty( static::$field_data ) )
+			static::unserialize_from_session();
+		
 		return static::$field_data;
 
 	}


### PR DESCRIPTION
FormBase_Model::all() Wasn't working unless FormBase_Model::get() was called first. Small change fixes that.
